### PR TITLE
Add Default StudioName

### DIFF
--- a/cloudformation/emr-studio-cluster.cfn.yaml
+++ b/cloudformation/emr-studio-cluster.cfn.yaml
@@ -8,6 +8,7 @@ Parameters:
     Description: "Studio Name - can include letters (A-Z and a-z), numbers (0-9), and dashes (-)."
     AllowedPattern: ^[a-zA-Z0-9-]*$
     ConstraintDescription: "Must only include letters (A-Z and a-z), numbers (0-9), and dashes (-)."
+    Default: "data-lake-blog"
 
   # Use public Systems Manager Parameter for Latest AMI ID for Amazon Linux 2
   LatestAmiId:


### PR DESCRIPTION
I'm new to CloudFormation. When I tried to deploy the stack, aws cli complained about a missing value in StudioName. You may also want to include sth like this to your README.
```bash
aws cloudformation deploy \
    --template-file cloudformation/emr-studio-cluster.cfn.yaml \
    --stack-name hudi-tutorial \
    --capabilities CAPABILITY_NAMED_IAM
```
Thanks a lot for the great introduction video 👍!